### PR TITLE
added event hooks

### DIFF
--- a/classes/MagicForm.php
+++ b/classes/MagicForm.php
@@ -4,6 +4,7 @@
 
     use AjaxException, Lang, Redirect, Request, Session, Validator;
     use Cms\Classes\ComponentBase;
+    use Illuminate\Support\Facades\Event;
     use October\Rain\Exception\ApplicationException;
     use October\Rain\Exception\ValidationException;
     use October\Rain\Support\Facades\Flash;
@@ -154,6 +155,8 @@
             # REMOVE EXTRA FIELDS FROM STORED DATA
             unset($post['_token'], $post['g-recaptcha-response'], $post['_session_key'], $post['_uploader']);
 
+            Event::fire('martin.forms.beforeSaveRecord', json_encode($post));
+
             # SAVE RECORD TO DATABASE
             $record = new Record;
             $record->ip        = $this->getIP();
@@ -171,6 +174,8 @@
                 SendMail::sendAutoResponse($this->getProperties(), $post);
             }
             
+            Event::fire('martin.forms.afterSaveRecord', json_encode($post));
+
             # CHECK FOR REDIRECT
             if(filter_var($this->property('redirect'), FILTER_VALIDATE_URL)) {
                 return Redirect::to($this->property('redirect'));


### PR DESCRIPTION
This PR causes the plugin to dispatch events through the October framework before and after saving a record, in order for others to extend the action with custom handlers. 

This is to better support issues along the lines of: 
- https://github.com/skydiver/october-plugin-forms/issues/5 
- https://github.com/skydiver/october-plugin-forms/issues/46 

A snippet implementation from my use-case: 
- from https://github.com/therealkevinard/oc-plugin-rwm-mfcontactsview 
```PHP 
<?php namespace Rwm\MfContactsView;

use Illuminate\Support\Facades\Event;
use System\Classes\PluginBase;

class Plugin extends PluginBase
{
    // ... other plugin setup ... 
    
    public function boot()
    {
        /**
         * In my particular use-case, I've used this event hook in a custom plugin to render the form data in a tailored way. A lightweight backend plugin in my namespace
         *  listend for the MF beforeSaveRecord, and performs custom mutation\persistence with the raw form data passed along with the event.
         *
         *  Magic Forms still manages all front-end display, and manages datastore for all forms - but client pushed for this specific form to have a certain view.
         */
        Event::listen('martin.forms.beforeSaveRecord', function ($formdata) {
            $contact = json_decode($formdata);
            xdebug_break();
            //-- Now do something with $formdata (which contains the complete json_encode of the original form data.)
        });

        Event::listen('martin.forms.afterSaveRecord', function ($formdata) {
            $contact = json_decode($formdata);
            xdebug_break();
        });
    }

    // ... other plugin setup ... 

}
```
