### PR TITLE
unicode encoding to form data

### DIFF
--- a/classes/MagicForm.php
+++ b/classes/MagicForm.php
@@ -171,7 +171,7 @@
             # SAVE RECORD TO DATABASE
             $record = new Record;
             $record->ip        = $this->getIP();
-            $record->form_data = json_encode($post);
+            $record->form_data = json_encode($post, JSON_UNESCAPED_UNICODE);
             if($this->property('group') != '') { $record->group = $this->property('group'); }
             $record->save(null, post('_session_key'));
 


### PR DESCRIPTION
This help to save characters in database in correct encoding. Without this, search functionality on form data won't work properly