### PR TITLE
Possibility to change the text on the remove file popup

### DIFF
--- a/components/UploadForm.php
+++ b/components/UploadForm.php
@@ -22,6 +22,7 @@
             $this->fileTypes       = $this->processFileTypes(true);
             $this->maxSize         = $this->property('maxSize');
             $this->placeholderText = $this->property('placeholderText');
+            $this->removeText      = $this->property('removeText');
             $this->setProperty('deferredBinding', 1);
             $this->bindModel('files', new Record);
         }
@@ -65,6 +66,14 @@
                     'title'             => 'martin.forms::lang.components.shared.uploader_pholder.title',
                     'description'       => 'martin.forms::lang.components.shared.uploader_pholder.description',
                     'default'           => Lang::get('martin.forms::lang.components.shared.uploader_pholder.default'),
+                    'type'              => 'string',
+                    'group'             => 'martin.forms::lang.components.shared.group_uploader',
+                    'showExternalParam' => false,
+                ],
+                'removeText' => [
+                    'title'             => 'martin.forms::lang.components.shared.uploader_remFile.title',
+                    'description'       => 'martin.forms::lang.components.shared.uploader_remFile.description',
+                    'default'           => Lang::get('martin.forms::lang.components.shared.uploader_remFile.default'),
                     'type'              => 'string',
                     'group'             => 'martin.forms::lang.components.shared.group_uploader',
                     'showExternalParam' => false,

--- a/components/uploadform/file-multi.htm
+++ b/components/uploadform/file-multi.htm
@@ -36,7 +36,7 @@
                         href="javascript:;"
                         class="upload-remove-button"
                         data-request="{{ __SELF__ ~ '::onRemoveAttachment' }}"
-                        data-request-confirm="Are you sure?"
+                        data-request-confirm="{{ __SELF__.removeText }}"
                         data-request-data="file_id: {{ file.id }}"
                         >&times;</a>
                 </div>
@@ -63,7 +63,7 @@
                 href="javascript:;"
                 class="upload-remove-button"
                 data-request="{{ __SELF__ ~ '::onRemoveAttachment' }}"
-                data-request-confirm="Are you sure?"
+                data-request-confirm="{{ __SELF__.removeText }}"
                 >&times;</a>
             <div class="progress-bar"><span class="upload-progress" data-dz-uploadprogress></span></div>
         </div>

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -107,6 +107,7 @@
                 'uploader_pholder'  => ['title' => 'Placeholder text'   , 'description' => 'Wording to display when no file is uploaded', 'default' => 'Click or drag files to upload'],
                 'uploader_maxsize'  => ['title' => 'File size limit'    , 'description' => 'The maximum file size that can be uploaded in megabytes'],
                 'uploader_types'    => ['title' => 'Allowed file types' , 'description' => 'Allowed file extensions or star (*) for all types (add one extension per line)'],
+                'uploader_remFile'  => ['title' => 'Remove Popup text'  , 'description' => 'Wording to display in the popup when you remove file', 'default' => 'Are you sure ?'],
             ]
         ],
 

--- a/lang/fr/lang.php
+++ b/lang/fr/lang.php
@@ -95,7 +95,7 @@
                 'uploader_pholder'  => ['title' => 'Texte de remplacement'           , 'description' => 'Texte à afficher quand aucun fichier n\'est téléchargé', 'default' => 'Cliquez pour choisir ou faites glisser les fichiers à télécharger'],
                 'uploader_maxsize'  => ['title' => 'Limite de taille de fichier'     , 'description' => 'Taille maximale du fichier pouvant être téléchargée en mégaoctets'],
                 'uploader_types'    => ['title' => 'Types de fichiers autorisés'     , 'description' => 'Extensions de fichiers autorisées ou étoile (*) pour tous les types (ajoutez une extension par ligne)'],
-                'uploader_remFile'  => ['title' => 'Texte de Suppression'            , 'description' => 'Texte à afficher dans la popuplors de la suppression d\'un fichier', 'default' => 'Êtes-vous sûr ?'],
+                'uploader_remFile'  => ['title' => 'Texte de Suppression'            , 'description' => 'Texte à afficher dans la popup lors de la suppression d\'un fichier', 'default' => 'Êtes-vous sûr ?'],
             ]
         ],
 

--- a/lang/fr/lang.php
+++ b/lang/fr/lang.php
@@ -95,6 +95,7 @@
                 'uploader_pholder'  => ['title' => 'Texte de remplacement'           , 'description' => 'Texte à afficher quand aucun fichier n\'est téléchargé', 'default' => 'Cliquez pour choisir ou faites glisser les fichiers à télécharger'],
                 'uploader_maxsize'  => ['title' => 'Limite de taille de fichier'     , 'description' => 'Taille maximale du fichier pouvant être téléchargée en mégaoctets'],
                 'uploader_types'    => ['title' => 'Types de fichiers autorisés'     , 'description' => 'Extensions de fichiers autorisées ou étoile (*) pour tous les types (ajoutez une extension par ligne)'],
+                'uploader_remFile'  => ['title' => 'Texte de Suppression'            , 'description' => 'Texte à afficher dans la popuplors de la suppression d\'un fichier', 'default' => 'Êtes-vous sûr ?'],
             ]
         ],
 

--- a/traits/FileUploader.php
+++ b/traits/FileUploader.php
@@ -13,6 +13,7 @@ trait FileUploader
 
     public $maxSize;
     public $placeholderText;
+    public $removeText;
 
     /**
      * Supported file types.
@@ -57,6 +58,12 @@ trait FileUploader
                 'default'     => 'Click or drag files to upload',
                 'type'        => 'string',
             ],
+            'removeText' => [
+                'title'       => 'Remove Popup text',
+                'description' => 'Wording to display in the popup when you remove file',
+                'default'     => 'Are you sure ?',
+                'type'        => 'string',
+            ],
             'maxSize' => [
                 'title'       => 'Max file size (MB)',
                 'description' => 'The maximum file size that can be uploaded in megabytes.',
@@ -82,6 +89,7 @@ trait FileUploader
         $this->fileTypes = $this->processFileTypes(true);
         $this->maxSize = $this->property('maxSize');
         $this->placeholderText = $this->property('placeholderText');
+        $this->removeText = $this->property('removeText');
     }
 
     public function onRun()


### PR DESCRIPTION
During the usage of your  plugin, I noticed that the text of the remove file popup was 'Are you sure ?' but my website is in french language

I think is good for all people to allow to change this text as the other strings

So I made changes on these files : 
- components/UploadForm.php
- components/uploadform/file-multi.htm
- traits/FileUploader.php
- lang/fr/lang.php
- lang/en/lang.php

With this we can modify the text on the component in the view with a input 'Remove Popup Text'.
I hope you accept this pull request.

Alexandre.

