### PR TITLE
Add basic Token support for notification subjects

### DIFF
--- a/classes/SendMail.php
+++ b/classes/SendMail.php
@@ -24,6 +24,14 @@ class SendMail {
             // CUSTOM TEMPLATE
             $template = isset($properties['mail_template']) && $properties['mail_template'] != '' && MailTemplate::where('code', $properties['mail_template'])->count() ? $properties['mail_template'] : 'martin.forms::mail.notification';
 
+            // REPLACE TOKENS IN SUBJECT
+            $properties['mail_subject'] = str_replace('{{ data.id }}', $data['id'], $properties['mail_subject']);
+            $properties['mail_subject'] = str_replace('{{ data.ip }}', $data['ip'], $properties['mail_subject']);
+            $properties['mail_subject'] = str_replace('{{ data.date }}', date('d/m/Y'), $properties['mail_subject']);
+            foreach($data['data'] as $key => $value) {
+                $properties['mail_subject'] = str_replace('{{ data.'.$key.' }}', $value, $properties['mail_subject']);
+            }
+            
             // SEND NOTIFICATION EMAIL
             Mail::sendTo($properties['mail_recipients'], $template, [
                     'id'   => $record->id,

--- a/classes/SendMail.php
+++ b/classes/SendMail.php
@@ -31,17 +31,22 @@ class SendMail {
                 'date' => $record->created_at
             ];
 
-            // REPLACE TOKENS IN SUBJECT
-            $properties['mail_subject'] = str_replace('{{ data.id }}', $data['id'], $properties['mail_subject']);
-            $properties['mail_subject'] = str_replace('{{ data.ip }}', $data['ip'], $properties['mail_subject']);
-            $properties['mail_subject'] = str_replace('{{ data.date }}', date('d/m/Y'), $properties['mail_subject']);
-            foreach($data['data'] as $key => $value) {
-                $properties['mail_subject'] = str_replace('{{ data.'.$key.' }}', $value, $properties['mail_subject']);
-            }
-
             // USE CUSTOM SUBJECT
             if (isset($properties['mail_subject'])) {
+
+                // REPLACE RECORD TOKENS IN SUBJECT
+                $properties['mail_subject'] = str_replace('{{ record.id }}', $data['id'], $properties['mail_subject']);
+                $properties['mail_subject'] = str_replace('{{ record.ip }}', $data['ip'], $properties['mail_subject']);
+                $properties['mail_subject'] = str_replace('{{ record.date }}', date('Y-m-d'), $properties['mail_subject']);
+
+                // REPLACE FORM FIELDS TOKENS IN SUBJECT
+                foreach ($data['data'] as $key => $value) {
+                    $properties['mail_subject'] = str_replace('{{ form.' . $key . ' }}', $value, $properties['mail_subject']);
+                }
+
+                // SET CUSTOM SUBJECT
                 $data['subject'] = $properties['mail_subject'];
+
             }
 
             // SEND NOTIFICATION EMAIL

--- a/classes/SendMail.php
+++ b/classes/SendMail.php
@@ -24,20 +24,20 @@ class SendMail {
             // CUSTOM TEMPLATE
             $template = isset($properties['mail_template']) && $properties['mail_template'] != '' && MailTemplate::where('code', $properties['mail_template'])->count() ? $properties['mail_template'] : 'martin.forms::mail.notification';
 
-            // REPLACE TOKENS IN SUBJECT
-            $properties['mail_subject'] = str_replace('{{ data.id }}', $data['id'], $properties['mail_subject']);
-            $properties['mail_subject'] = str_replace('{{ data.ip }}', $data['ip'], $properties['mail_subject']);
-            $properties['mail_subject'] = str_replace('{{ data.date }}', date('d/m/Y'), $properties['mail_subject']);
-            foreach($data['data'] as $key => $value) {
-                $properties['mail_subject'] = str_replace('{{ data.'.$key.' }}', $value, $properties['mail_subject']);
-            }          
-  
             $data = [
                 'id'   => $record->id,
                 'data' => $post,
                 'ip'   => $record->ip,
                 'date' => $record->created_at
             ];
+
+            // REPLACE TOKENS IN SUBJECT
+            $properties['mail_subject'] = str_replace('{{ data.id }}', $data['id'], $properties['mail_subject']);
+            $properties['mail_subject'] = str_replace('{{ data.ip }}', $data['ip'], $properties['mail_subject']);
+            $properties['mail_subject'] = str_replace('{{ data.date }}', date('d/m/Y'), $properties['mail_subject']);
+            foreach($data['data'] as $key => $value) {
+                $properties['mail_subject'] = str_replace('{{ data.'.$key.' }}', $value, $properties['mail_subject']);
+            }
 
             // USE CUSTOM SUBJECT
             if (isset($properties['mail_subject'])) {


### PR DESCRIPTION
Add basic token support for mail_subject.

You can use the following tokens in your mail subjects : 
- {{ data.id }} = the id of the record
- {{ data.ip }} = the ip of the sender
- {{ data.date }} = the actual date
- {{ data.$field }} = Where $field is the name of a field of your form to display the value of that field

See the issue : https://github.com/skydiver/october-plugin-forms/issues/87