### PR TITLE
GPRD compatible patch

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -93,6 +93,16 @@
                 Validator::extend('recaptcha', 'Martin\Forms\Classes\ReCaptchaValidator@validateReCaptcha');
             });
         }
+        
+        public function registerSchedule($schedule)
+        {
+            $schedule->call(function () {
+                $gprd = Settings::get('gprd', false);
+                if($gprd !== false) {
+                    $records = \Db::table('martin_forms_records')->whereDate('created_at', '<', Carbon::now()->subDays($gprd))->delete();
+                }
+            })->everyDays();
+        }
 
     }
 

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -123,6 +123,8 @@
             'section_recaptcha'       => 'reCAPTCHA Settings',
             'recaptcha_site_key'      => 'Site key',
             'recaptcha_secret_key'    => 'Secret key',
+            'gprd'                    => 'Keep records for maximum X days',
+            'gprd_desc'               => 'New GPRD law in Europe, you can\'t keep records undefinitely, need to clear them after a certain period of time depending on your needs',
         ],
 
         'permissions' => [

--- a/models/settings/fields.yaml
+++ b/models/settings/fields.yaml
@@ -25,6 +25,11 @@ tabs:
             type   : switch
             default: false
             tab    : martin.forms::lang.settings.tabs.general
+            
+        gprd:
+            label  : martin.forms::lang.settings.gprd
+            comment: martin.forms::lang.settings.gprd_desc
+            tab    : martin.forms::lang.settings.tabs.general
 
         #section_recaptcha:
         #    label: martin.forms::lang.settings.section_recaptcha


### PR DESCRIPTION
Hello,

EU will release a new law soon about data protection called GPRD.

There is one rule in that law that concern Magic Form, to be concise, with that law, you can't keep user submitted data indefinitely. You need to clear them regulary, depending on your needs.

That's why this PR add a setting in magic form to clear data after a certain number of days. If filled (30 for example), it will keep data for 30 days and automatically delete the ones that are older.

NB : It would be probably better to add this settings on the component level (next to "skip database" setting) and to clear records depending on each component settings, but it would add some complexity to the scheduling task that would need to know what is the component that registered the record (don't know if it's possible actually).