### PR TITLE
Return default app locale if no translate plugin is present

### DIFF
--- a/classes/ReCaptcha.php
+++ b/classes/ReCaptcha.php
@@ -35,6 +35,7 @@
         
         private function getReCaptchaLang($lang='') {
             if(BackendHelpers::isTranslatePlugin()) { $lang = '&hl=' . $this->activeLocale = $this->translator->getLocale(); }
+            else {  $lang = '&hl=' . $this->activeLocale = app()->getLocale(); }
             return $lang;
         }
 


### PR DESCRIPTION
If you have a page in language other than english but don's use Translate plugin, recaptcha will still be in english. This PR changes this so an app level locale is retrieved via app()->getLocale() instead.