### PR TITLE
set created_at column type so date gets shown with proper timezone

### DIFF
--- a/models/record/columns.yaml
+++ b/models/record/columns.yaml
@@ -28,3 +28,4 @@ columns:
 
     created_at:
         label: martin.forms::lang.controllers.records.columns.created_at
+        type: datetime


### PR DESCRIPTION
assign `type=datetime` instead of default `type=text` so that proper timezone dependant processing gets applied when displaying the `created_at` field when showing stored records.