### PR TITLE
Use unregistered mail view if it exists

### DIFF
--- a/classes/SendMail.php
+++ b/classes/SendMail.php
@@ -23,7 +23,7 @@ class SendMail {
         if (is_array($properties['mail_recipients']) || is_array($properties['mail_bcc'])) {
 
             // CUSTOM TEMPLATE
-            $template = isset($properties['mail_template']) && $properties['mail_template'] != '' && MailTemplate::where('code', $properties['mail_template'])->count() ? $properties['mail_template'] : 'martin.forms::mail.notification';
+            $template = isset($properties['mail_template']) && $properties['mail_template'] != '' && MailTemplate::findOrMakeTemplate($properties['mail_template']) ? $properties['mail_template'] : 'martin.forms::mail.notification';
 
             $data = [
                 'id'   => $record->id,
@@ -122,7 +122,7 @@ class SendMail {
         if (filter_var($to, FILTER_VALIDATE_EMAIL) && filter_var($from, FILTER_VALIDATE_EMAIL)) {
 
             // CUSTOM TEMPLATE
-            $template = isset($properties['mail_resp_template']) && $properties['mail_resp_template'] != '' && MailTemplate::where('code', $properties['mail_resp_template'])->count() ? $properties['mail_resp_template'] : 'martin.forms::mail.autoresponse';
+            $template = isset($properties['mail_resp_template']) && $properties['mail_resp_template'] != '' && MailTemplate::findOrMakeTemplate($properties['mail_resp_template']) ? $properties['mail_resp_template'] : 'martin.forms::mail.autoresponse';
 
             Mail::sendTo($to, $template, [
                     'id'   => $record->id,


### PR DESCRIPTION
This small change will allow using an existing mail view even if it has not been registered by the plugin. The mail_template should refer to the fully qualified view path (e.g. "author.plugin::mail.myview")